### PR TITLE
Replacing undefined getPrimaryKey method with the raw ddb.id value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -253,7 +253,7 @@ class DDBHandler {
   async delete(key) {
     const params = {
       TableName: this.tableName,
-      Key: key ? key : this.getPrimaryKey()
+      Key: key ? key : this.id
     };
     await ddb.delete(params).promise();
     return this;


### PR DESCRIPTION
### Description
getPrimaryKey was not defined in DDBHandler class. 

Wasn't sure if the intention was to be a wrapper for `this.id` or to include additional logic but for now I removed the method reference to avoid getting an error.