### PR TITLE
Added support for dot syntax in updateExpressions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raydeck/ddb-manager",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Base class for managing DynamoDB model",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
### Change
This PR allows for update expressions that look like
`updateExpression: "parent.child.grandchild=x"`

Otherwise, I would have to update the parent object whole sale which leads to race conditions.


### Limitation
I did not introduce any type of recovery mechanism if a field in the map does not exist.


E.g. The following expression, `updateExpression: "parent.child.grandchild=x"`, would throw an error in js land if Item looks like

```
{
  parent: {}
}
```


I think with this limitation the library is better than it was before