### PR TITLE
Fixed uuids to be used in update expression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { DynamoDB } from "aws-sdk";
+import { createHash } from "crypto";
 const ddb = new DynamoDB.DocumentClient();
 const scanAll = async params => {
   return await scanMap(params, o => o);
@@ -209,21 +210,20 @@ class DDBHandler {
     const ExpressionAttributeNames = {};
     const ExpressionAttributeValues = {};
     const updateStatements = [];
-    const crypto = require("crypto");
 
     this.processUpdates(updates).forEach(([field, value]) => {
       if (value === "") value = null;
       if (field.includes(".")) {
-        const md5sum = crypto.createHash("md5");
+        const md5sum = createHash("md5");
         md5sum.update(field);
         const normalizedValueVariable = `:${md5sum.digest("hex")}`;
         ExpressionAttributeValues[normalizedValueVariable] = value;
         const normalizedNameVariable = field
           .split(".")
           .map(part => {
-            const md5sum = crypto.createHash("md5");
-            md5sum.update(part);
-            const newPart = `#${md5sum.digest("hex")}`;
+            const newPart = `#${createHash("md5")
+              .update(part)
+              .digest("hex")}`;
             ExpressionAttributeNames[newPart] = part;
             return newPart;
           })
@@ -232,9 +232,12 @@ class DDBHandler {
           `${normalizedNameVariable} = ${normalizedValueVariable}`
         );
       } else {
-        updateStatements.push(`#${field} = :${field}`);
-        ExpressionAttributeNames[`#${field}`] = field;
-        ExpressionAttributeValues[`:${field}`] = value;
+        const newPart = `#${createHash("md5")
+          .update(field)
+          .digest("hex")}`;
+        updateStatements.push(`#${newPart} = :${field}`);
+        ExpressionAttributeNames[`#${newPart}`] = field;
+        ExpressionAttributeValues[`:${newPart}`] = value;
       }
     });
     if (updateStatements.length) {


### PR DESCRIPTION
### Change(s)
Hashed SET "path" name to allow document names with special characters, like a v4 uuid.

Names that include a "-" will result in a syntax error. MD5 hashing will result in a unique string that is allowed in update expressions