### PR TITLE
Fixed variable name for expression attribute value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,7 @@ class DDBHandler {
         const newPart = `${createHash("md5")
           .update(field)
           .digest("hex")}`;
-        updateStatements.push(`#${newPart} = :${field}`);
+        updateStatements.push(`#${newPart} = :${newPart}`);
         ExpressionAttributeNames[`#${newPart}`] = field;
         ExpressionAttributeValues[`:${newPart}`] = value;
       }


### PR DESCRIPTION
There was a mismatch between the variable name for ":value" defined in the "UpdateExpression" vs "ExpressAttributeValues"